### PR TITLE
coef.dmr fix

### DIFF
--- a/R/dmr.R
+++ b/R/dmr.R
@@ -79,7 +79,7 @@ dmr <- function(cl, covars, counts, mu=NULL, bins=NULL, verb=0, cv=FALSE, ...)
 coef.dmr <- function(object, ...){
   B <- lapply(object,coef, ...)
   failures <- sapply(B,is.null)
-  for (i in which(failures == TRUE)) B[[i]] <- Matrix(0)
+  for (i in which(failures == TRUE)) B[[i]] <- Matrix(0, doDiag = FALSE)
   bx <- unlist(lapply(B,function(b) b@x))
   bi <- unlist(lapply(B,function(b) b@i))
   bp <- c(0,


### PR DESCRIPTION
Following up on the pull request that I submitted in June 2021. Changes to the Matrix package in version 1.3-1 altered the default behavior of the `Matrix()` command. This causes the command `Matrix(0)` to now return a ddiMatrix diagonal matrix instead of a dsCMatrix. This change leads to an error when computing DMR coefficients of a counts matrix that has multiple columns with no observations. Adding the argument `doDiag = FALSE` creates a dsCMatrix and solves the issue.

The changes in the default behavior of `Matrix()` is documented in the NEWS of the Matrix package. Note the last line that identifies why the code in `coef.dmr()` will break:

**Changes in version 1.3-0 (2020-12-15 r3351)**
**Significant User-Visible Change**

`Matrix(*, doDiag=TRUE)` where `doDiag=TRUE` has always been the default is now obeyed also in the sparse case, as all "diagonalMatrix" are also "sparseMatrix".

`Matrix(0, 3,3)` returns a "ddiMatrix" instead of a "dsCMatrix" previously. The latter is still returned from `Matrix(0, 3,3, doDiag=FALSE)`, and e.g., `.symDiagonal(3,pi).`

Also a triangular matrix, e.g., "dtrMatrix" is detected now in cases with NAs.

This is both a bug fix and an API change which breaks code that assumes `Matrix(.)` to return a "CsparseMatrix" in cases where it now returns a "diagonalMatrix" (which does extend "sparseMatrix").
